### PR TITLE
Return the modified key on WatchTree call for etcd v3

### DIFF
--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -267,7 +267,7 @@ func (s *EtcdV3) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*
 
 			for i, ev := range resp.Events {
 				list[i] = &store.KVPair{
-					Key:       directory,
+					Key:       string(ev.Kv.Key),
 					Value:     []byte(ev.Kv.Value),
 					LastIndex: uint64(ev.Kv.ModRevision),
 				}


### PR DESCRIPTION
We were returning the directory key for the WatchTree call,
thus every event triggered by the watch would have the directory
as a key, making it impossible to triage and identify which key
was modified.

Signed-off-by: Alexandre Beslic <abeslic@abronan.com>