### PR TITLE
Etcd v3: add WithSerializable flag to List call

### DIFF
--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -485,7 +485,7 @@ func (s *EtcdV3) Close() {
 // list child nodes of a given directory and return revision number
 func (s *EtcdV3) list(directory string) (int64, []*store.KVPair, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), etcdDefaultTimeout)
-	resp, err := s.client.KV.Get(ctx, s.normalize(directory), etcd.WithPrefix(), etcd.WithSort(etcd.SortByKey, etcd.SortDescend))
+	resp, err := s.client.KV.Get(ctx, s.normalize(directory), etcd.WithSerializable(), etcd.WithPrefix(), etcd.WithSort(etcd.SortByKey, etcd.SortDescend))
 	cancel()
 	if err != nil {
 		return 0, nil, err


### PR DESCRIPTION
To keep things consistent with the "consistency by default"
behavior and the fact that the simple Get call uses the flag:
'WithSerializable' to keep reads consistent, we add the flag
to the List call as well.

Signed-off-by: Alexandre Beslic <abeslic@abronan.com>