### PR TITLE
Filter ETCD side key from ETCD V3 List.

### DIFF
--- a/store/etcd/v2/etcd.go
+++ b/store/etcd/v2/etcd.go
@@ -420,10 +420,6 @@ func (s *Etcd) List(directory string) ([]*store.KVPair, error) {
 
 	kv := []*store.KVPair{}
 	for _, n := range resp.Node.Nodes {
-		// Allow to filter the _lock entry when the mutex key directory is given
-		if directory == s.writeKey && string(n.Key) == s.mutexKey {
-			continue
-		}
 		kv = append(kv, &store.KVPair{
 			Key:       n.Key,
 			Value:     []byte(n.Value),

--- a/store/etcd/v2/etcd_test.go
+++ b/store/etcd/v2/etcd_test.go
@@ -56,20 +56,3 @@ func TestEtcdStore(t *testing.T) {
 	testutils.RunTestTTL(t, kv, ttlKV)
 	testutils.RunCleanup(t, kv)
 }
-
-func TestEtcdListLockKey(t *testing.T) {
-	key := "testLockUnlock"
-	lockKV := makeEtcdClient(t)
-	value := []byte("bar")
-
-	// We should be able to create a new lock on key
-	lock, err := lockKV.NewLock(key, &store.LockOptions{Value: value, TTL: 2 * time.Second})
-	assert.NoError(t, err)
-	assert.NotNil(t, lock)
-
-	pairs, err := lockKV.List(key)
-	assert.NoError(t, err)
-	assert.NotNil(t, pairs)
-	assert.Equal(t, 1, len(pairs))
-	assert.Equal(t, key, pairs[0].Key)
-}

--- a/store/etcd/v2/etcd_test.go
+++ b/store/etcd/v2/etcd_test.go
@@ -56,3 +56,20 @@ func TestEtcdStore(t *testing.T) {
 	testutils.RunTestTTL(t, kv, ttlKV)
 	testutils.RunCleanup(t, kv)
 }
+
+func TestEtcdListLockKey(t *testing.T) {
+	key := "testLockUnlock"
+	lockKV := makeEtcdClient(t)
+	value := []byte("bar")
+
+	// We should be able to create a new lock on key
+	lock, err := lockKV.NewLock(key, &store.LockOptions{Value: value, TTL: 2 * time.Second})
+	assert.NoError(t, err)
+	assert.NotNil(t, lock)
+
+	pairs, err := lockKV.List(key)
+	assert.NoError(t, err)
+	assert.NotNil(t, pairs)
+	assert.Equal(t, 1, len(pairs))
+	assert.Equal(t, key, pairs[0].Key)
+}

--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -505,7 +505,7 @@ func (s *EtcdV3) list(directory string) (int64, []*store.KVPair, error) {
 
 	for _, n := range resp.Kvs {
 		// Allow to filter the _lock entry when the mutex key directory is given
-		if directory == s.writeKey && string(n.Key) == s.mutexKey {
+		if directory == s.writeKey && strings.Split(string(n.Key), "/")[0] == s.mutexKey {
 			continue
 		}
 		kv = append(kv, &store.KVPair{

--- a/store/etcd/v3/etcd_test.go
+++ b/store/etcd/v3/etcd_test.go
@@ -56,3 +56,20 @@ func TestEtcdV3Store(t *testing.T) {
 	testutils.RunTestTTL(t, kv, ttlKV)
 	testutils.RunCleanup(t, kv)
 }
+
+func TestEtcdListLockKey(t *testing.T) {
+	key := "testLockUnlock"
+	lockKV := makeEtcdV3Client(t)
+	value := []byte("bar")
+
+	// We should be able to create a new lock on key
+	lock, err := lockKV.NewLock(key, &store.LockOptions{Value: value, TTL: 2 * time.Second})
+	assert.NoError(t, err)
+	assert.NotNil(t, lock)
+
+	pairs, err := lockKV.List(key)
+	assert.NoError(t, err)
+	assert.NotNil(t, pairs)
+	assert.Equal(t, 1, len(pairs))
+	assert.Equal(t, key, pairs[0].Key)
+}

--- a/store/etcd/v3/etcd_test.go
+++ b/store/etcd/v3/etcd_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	client = "localhost:4001"
+	client = "localhost:2379"
 )
 
 func makeEtcdV3Client(t *testing.T) store.Store {
@@ -58,14 +58,20 @@ func TestEtcdV3Store(t *testing.T) {
 }
 
 func TestEtcdListLockKey(t *testing.T) {
-	key := "testLockUnlock"
 	lockKV := makeEtcdV3Client(t)
+
+	key := "testLocketcdv3"
 	value := []byte("bar")
 
 	// We should be able to create a new lock on key
 	lock, err := lockKV.NewLock(key, &store.LockOptions{Value: value, TTL: 2 * time.Second})
 	assert.NoError(t, err)
 	assert.NotNil(t, lock)
+
+	// Lock should successfully succeed or block
+	lockChan, err := lock.Lock(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, lockChan)
 
 	pairs, err := lockKV.List(key)
 	assert.NoError(t, err)

--- a/store/etcd/v3/etcd_test.go
+++ b/store/etcd/v3/etcd_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	client = "localhost:2379"
+	client = "localhost:4001"
 )
 
 func makeEtcdV3Client(t *testing.T) store.Store {


### PR DESCRIPTION
ETCD needs a *side key* for all the *mutex keys* generated.

When the `List` method is called with the *mutex key* as parameter, the *side key* (which has the name as the *mutex key* plus the suffix *_lock*) is returned.

This kind of behavior is not homogeneous with the other store and additional development is needed in project which use libkv.

This PR allow filtering the *side key* Pair for ETC V3.