### PR TITLE
Make the List method homogeneous between all stores

### DIFF
--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -275,7 +275,7 @@ func (b *BoltDB) List(keyPrefix string) ([]*store.KVPair, error) {
 		return nil, err
 	}
 	defer b.releaseDBhandle()
-
+	hasResult := false
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
@@ -286,23 +286,24 @@ func (b *BoltDB) List(keyPrefix string) ([]*store.KVPair, error) {
 		prefix := []byte(keyPrefix)
 
 		for key, v := cursor.Seek(prefix); bytes.HasPrefix(key, prefix); key, v = cursor.Next() {
+			hasResult = true
 			dbIndex := binary.LittleEndian.Uint64(v[:libkvmetadatalen])
 			v = v[libkvmetadatalen:]
 			val := make([]byte, len(v))
 			copy(val, v)
 
-			kv = append(kv, &store.KVPair{
-				Key:       string(key),
-				Value:     val,
-				LastIndex: dbIndex,
-			})
+			if string(key) != keyPrefix {
+				kv = append(kv, &store.KVPair{
+					Key:       string(key),
+					Value:     val,
+					LastIndex: dbIndex,
+				})
+			}
 		}
 		return nil
 	})
-	if len(kv) == 0 {
+	if !hasResult {
 		return nil, store.ErrKeyNotFound
-	} else if len(kv) == 1 && kv[0].Key == keyPrefix {
-		return []*store.KVPair{}, err
 	}
 	return kv, err
 }

--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -286,7 +286,6 @@ func (b *BoltDB) List(keyPrefix string) ([]*store.KVPair, error) {
 		prefix := []byte(keyPrefix)
 
 		for key, v := cursor.Seek(prefix); bytes.HasPrefix(key, prefix); key, v = cursor.Next() {
-
 			dbIndex := binary.LittleEndian.Uint64(v[:libkvmetadatalen])
 			v = v[libkvmetadatalen:]
 			val := make([]byte, len(v))
@@ -302,6 +301,8 @@ func (b *BoltDB) List(keyPrefix string) ([]*store.KVPair, error) {
 	})
 	if len(kv) == 0 {
 		return nil, store.ErrKeyNotFound
+	} else if len(kv) == 1 && kv[0].Key == keyPrefix {
+		return []*store.KVPair{}, err
 	}
 	return kv, err
 }

--- a/store/etcd/v2/etcd.go
+++ b/store/etcd/v2/etcd.go
@@ -418,6 +418,9 @@ func (s *Etcd) List(directory string) ([]*store.KVPair, error) {
 
 	kv := []*store.KVPair{}
 	for _, n := range resp.Node.Nodes {
+		if n.Key == directory {
+			continue
+		}
 		kv = append(kv, &store.KVPair{
 			Key:       n.Key,
 			Value:     []byte(n.Value),

--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -498,6 +498,10 @@ func (s *EtcdV3) list(directory string) (int64, []*store.KVPair, error) {
 	kv := []*store.KVPair{}
 
 	for _, n := range resp.Kvs {
+		if string(n.Key) == directory {
+			continue
+		}
+
 		kv = append(kv, &store.KVPair{
 			Key:       string(n.Key),
 			Value:     []byte(n.Value),

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -502,7 +502,8 @@ func testPutTTL(t *testing.T, kv store.Store, otherConn store.Store) {
 }
 
 func testList(t *testing.T, kv store.Store) {
-	prefix := "testList"
+	parentKey := "testList"
+	parentValue := []byte("parent")
 
 	firstKey := "testList/first"
 	firstValue := []byte("first")
@@ -510,16 +511,20 @@ func testList(t *testing.T, kv store.Store) {
 	secondKey := "testList/second"
 	secondValue := []byte("second")
 
-	// Put the first key
-	err := kv.Put(firstKey, firstValue, nil)
+	// Put the parent key
+	err := kv.Put(parentKey, parentValue, nil)
 	assert.NoError(t, err)
 
-	// Put the second key
+	// Put the first child key
+	err = kv.Put(firstKey, firstValue, nil)
+	assert.NoError(t, err)
+
+	// Put the second child key
 	err = kv.Put(secondKey, secondValue, nil)
 	assert.NoError(t, err)
 
 	// List should work and return the two correct values
-	for _, parent := range []string{prefix, prefix + "/"} {
+	for _, parent := range []string{parentKey, parentKey + "/"} {
 		pairs, err := kv.List(parent)
 		assert.NoError(t, err)
 		if assert.NotNil(t, pairs) {

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -523,20 +523,27 @@ func testList(t *testing.T, kv store.Store) {
 		pairs, err := kv.List(parent)
 		assert.NoError(t, err)
 		if assert.NotNil(t, pairs) {
-			assert.Equal(t, len(pairs), 2)
+			assert.Equal(t, 2, len(pairs))
 		}
 
 		// Check pairs, those are not necessarily in Put order
 		for _, pair := range pairs {
 			if pair.Key == firstKey {
-				assert.Equal(t, pair.Value, firstValue)
+				assert.Equal(t, firstValue, pair.Value)
 			}
 			if pair.Key == secondKey {
-				assert.Equal(t, pair.Value, secondValue)
+				assert.Equal(t, secondValue, pair.Value)
 			}
 		}
 	}
-
+	// List should work and return 0 value
+	for _, key := range []string{firstKey, secondKey} {
+		pairs, err := kv.List(key)
+		assert.NoError(t, err)
+		if assert.NotNil(t, pairs) {
+			assert.Equal(t, 0, len(pairs))
+		}
+	}
 	// List should fail: the key does not exist
 	pairs, err := kv.List("idontexist")
 	assert.Equal(t, store.ErrKeyNotFound, err)

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -503,7 +503,7 @@ func testPutTTL(t *testing.T, kv store.Store, otherConn store.Store) {
 
 func testList(t *testing.T, kv store.Store) {
 	parentKey := "testList"
-	parentValue := []byte("parent")
+	//parentValue := []byte("parent")
 
 	firstKey := "testList/first"
 	firstValue := []byte("first")
@@ -512,7 +512,7 @@ func testList(t *testing.T, kv store.Store) {
 	secondValue := []byte("second")
 
 	// Put the parent key
-	err := kv.Put(parentKey, parentValue, nil)
+	err := kv.Put(parentKey, nil, &store.WriteOptions{IsDir: true})
 	assert.NoError(t, err)
 
 	// Put the first child key


### PR DESCRIPTION
When the `List()` method is called for the etcd provider, a **Pair** with the given key is returned in the result.

This behavior is different than the others stores which only return the children `Pairs`.

The PR allows filtering this _root_ `Pair` from the result for ETCD V2 and V3.