### PR TITLE
Allow to specify consul scheme (only HTTP is allowed at the moment)

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -74,8 +74,7 @@ func New(endpoints []string, options *store.Config) (store.Store, error) {
 	s.config = config
 	config.HttpClient = http.DefaultClient
 	config.Address = endpoints[0]
-	config.Scheme = "http"
-
+	
 	// Set options
 	if options != nil {
 		if options.TLS != nil {


### PR DESCRIPTION
Hello!

This line https://github.com/docker/libkv/blob/master/store/consul/consul.go#L77 overwrites the setting that I am trying to pass via the environment variable CONSUL_HTTP_SSL to the hashicorp API. This makes impossible to connect to a consul server with HTTPS, and it is causing an issue in Traefik: containous/traefik#1275.

Fixing the scheme to "https" shouldn't be necessary, as the hashicorp API does it by default (https://github.com/hashicorp/consul/blob/8a5164e14aa5464f807eed493c2fb70329ef2135/api/api.go#L216), so I guess you could remove that line.