### PR TITLE
meta: Standardize results of List call for every backend

### DIFF
--- a/store/etcd/v2/etcd.go
+++ b/store/etcd/v2/etcd.go
@@ -428,6 +428,9 @@ func (s *Etcd) List(directory string, opts *store.ReadOptions) ([]*store.KVPair,
 
 	kv := []*store.KVPair{}
 	for _, n := range resp.Node.Nodes {
+		if n.Key == directory {
+			continue
+		}
 		kv = append(kv, &store.KVPair{
 			Key:       n.Key,
 			Value:     []byte(n.Value),

--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -516,6 +516,10 @@ func (s *EtcdV3) list(directory string, opts *store.ReadOptions) (int64, []*stor
 	kv := []*store.KVPair{}
 
 	for _, n := range resp.Kvs {
+		if string(n.Key) == directory {
+			continue
+		}
+
 		kv = append(kv, &store.KVPair{
 			Key:       string(n.Key),
 			Value:     []byte(n.Value),

--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -146,16 +146,14 @@ func (s *EtcdV3) Put(key string, value []byte, opts *store.WriteOptions) (err er
 	ctx, cancel := context.WithTimeout(context.Background(), etcdDefaultTimeout)
 	pr := s.client.Txn(ctx)
 
-	if opts != nil {
-		if opts.TTL > 0 {
-			lease := etcd.NewLease(s.client)
-			resp, err := lease.Grant(context.Background(), int64(opts.TTL/time.Second))
-			if err != nil {
-				cancel()
-				return err
-			}
-			pr.Then(etcd.OpPut(key, string(value), etcd.WithLease(resp.ID)))
+	if opts != nil && opts.TTL > 0 {
+		lease := etcd.NewLease(s.client)
+		resp, err := lease.Grant(context.Background(), int64(opts.TTL/time.Second))
+		if err != nil {
+			cancel()
+			return err
 		}
+		pr.Then(etcd.OpPut(key, string(value), etcd.WithLease(resp.ID)))
 	} else {
 		pr.Then(etcd.OpPut(key, string(value)))
 	}


### PR DESCRIPTION
Carry #32 
____

List is used to list child keys of a directory, whether
recursively over the entire tree and subfolders or just
direct childs.

Results from the List calls where inconsistent on every
backend, some would return the direct children while others
would return the recursive result by default, some backends
would include the directory key in the result, etc.

This PR normalizes the result of the List call to be the
same on every store for the recursive version.

For example, considering this tree:

    parent/
    parent/child
    parent/subfolder
    parent/subfolder/child1
    parent/subfolder/child2
    parent/subfolder/child3

If we call 'List' on "parent", the result of the List call
will be:

    parent/child
    parent/subfolder
    parent/subfolder/child1
    parent/subfolder/child2
    parent/subfolder/child3

Signed-off-by: Alexandre Beslic <abeslic@abronan.com>