### PR TITLE
meta: Introduce ReadOptions to store interface with Consistency flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ A **storage backend** in `libkv` should implement (fully or partially) these int
 ```go
 type Store interface {
 	Put(key string, value []byte, options *WriteOptions) error
-	Get(key string) (*KVPair, error)
+	Get(key string, options *ReadOptions) (*KVPair, error)
 	Delete(key string) error
-	Exists(key string) (bool, error)
-	Watch(key string, stopCh <-chan struct{}) (<-chan *KVPair, error)
-	WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*KVPair, error)
+	Exists(key string, options *ReadOptions) (bool, error)
+	Watch(key string, stopCh <-chan struct{}, options *ReadOptions) (<-chan *KVPair, error)
+	WatchTree(directory string, stopCh <-chan struct{}, options *ReadOptions) (<-chan []*KVPair, error)
 	NewLock(key string, options *LockOptions) (Locker, error)
-	List(directory string) ([]*KVPair, error)
+	List(directory string, options *ReadOptions) ([]*KVPair, error)
 	DeleteTree(directory string) error
 	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
 	AtomicDelete(key string, previous *KVPair) (bool, error)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -42,10 +42,10 @@ When initializing the `WatchTree`, the natural way to do so is through the follo
 
 ```go
 key := "path/to/key"
-if !kv.Exists(key) {
+if !kv.Exists(key, nil) {
     err := kv.Put(key, []byte("data"), nil)
 }
-events, err := kv.WatchTree(key, nil)
+events, err := kv.WatchTree(key, nil, nil)
 ```
 
 The code above will not work across backends and etcd with **APIv2** will fail on the `WatchTree` call. What happens exactly:
@@ -58,11 +58,11 @@ To use `WatchTree` with every supported backend, we need to enforce a parameter 
 
 ```go
 key := "path/to/key"
-if !kv.Exists(key) {
+if !kv.Exists(key, nil) {
     // We enforce IsDir = true to make sure etcd creates a directory
     err := kv.Put(key, []byte("data"), &store.WriteOptions{IsDir:true})
 }
-events, err := kv.WatchTree(key, nil)
+events, err := kv.WatchTree(key, nil, nil)
 ```
 
 The code above will work for all backends but make sure not to try to store any value on that path as the call to `Put` will fail for `etcd` (you can only put at `path/to/key/foo`, `path/to/key/bar` for example).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -54,7 +54,7 @@ func main() {
         fmt.Errorf("Error trying to put value at key: %v", key)
     }
 
-    pair, err := kv.Get(key)
+    pair, err := kv.Get(key, nil)
     if err != nil {
         fmt.Errorf("Error trying accessing value at key: %v", key)
     }
@@ -72,7 +72,7 @@ func main() {
 
 ```go
 // List will list all the keys under `key` if it contains a set of child keys/values
-entries, err := kv.List(key)
+entries, err := kv.List(key, nil)
 for _, pair := range entries {
     fmt.Printf("key=%v - value=%v", pair.Key, string(pair.Value))
 }
@@ -85,7 +85,7 @@ You can use watches to watch modifications on a key. First you need to check if 
 
 ```go
 // Checking on the key before watching
-if !kv.Exists(key) {
+if !kv.Exists(key, nil) {
     err := kv.Put(key, []byte("bar"), nil)
     if err != nil {
         fmt.Errorf("Something went wrong when initializing key %v", key)
@@ -93,7 +93,7 @@ if !kv.Exists(key) {
 }
 
 stopCh := make(<-chan struct{})
-events, err := kv.Watch(key, stopCh)
+events, err := kv.Watch(key, stopCh, nil)
 
 for {
     select {
@@ -111,7 +111,7 @@ You can use watches to watch modifications on a key. First you need to check if 
 
 ```go
 // Checking on the key before watching
-if !kv.Exists(key) {
+if !kv.Exists(key, nil) {
     // Do not forget `IsDir:true` if you are using etcd APIv2
     err := kv.Put(key, []byte("bar"), &store.WriteOptions{IsDir:true})
     if err != nil {
@@ -120,7 +120,7 @@ if !kv.Exists(key) {
 }
 
 stopCh := make(<-chan struct{})
-events, err := kv.WatchTree(key, stopCh)
+events, err := kv.WatchTree(key, stopCh, nil)
 
 select {
     case pairs := <-events:
@@ -152,7 +152,7 @@ if err != nil {
 }
 
 // Get should work because we are holding the key
-pair, err := kv.Get(key)
+pair, err := kv.Get(key, nil)
 if err != nil {
     fmt.Errorf("key %v has value %v", key, pair.Value)
 }

--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -127,7 +127,7 @@ func (b *BoltDB) releaseDBhandle() {
 
 // Get the value at "key". BoltDB doesn't provide an inbuilt last modified index with every kv pair. Its implemented by
 // by a atomic counter maintained by the libkv and appened to the value passed by the client.
-func (b *BoltDB) Get(key string) (*store.KVPair, error) {
+func (b *BoltDB) Get(key string, opts *store.ReadOptions) (*store.KVPair, error) {
 	var (
 		val []byte
 		db  *bolt.DB
@@ -229,7 +229,7 @@ func (b *BoltDB) Delete(key string) error {
 }
 
 // Exists checks if the key exists inside the store
-func (b *BoltDB) Exists(key string) (bool, error) {
+func (b *BoltDB) Exists(key string, opts *store.ReadOptions) (bool, error) {
 	var (
 		val []byte
 		db  *bolt.DB
@@ -261,7 +261,7 @@ func (b *BoltDB) Exists(key string) (bool, error) {
 }
 
 // List returns the range of keys starting with the passed in prefix
-func (b *BoltDB) List(keyPrefix string) ([]*store.KVPair, error) {
+func (b *BoltDB) List(keyPrefix string, opts *store.ReadOptions) ([]*store.KVPair, error) {
 	var (
 		db  *bolt.DB
 		err error
@@ -464,11 +464,11 @@ func (b *BoltDB) NewLock(key string, options *store.LockOptions) (store.Locker, 
 }
 
 // Watch has to implemented at the library level since its not supported by BoltDB
-func (b *BoltDB) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+func (b *BoltDB) Watch(key string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan *store.KVPair, error) {
 	return nil, store.ErrCallNotSupported
 }
 
 // WatchTree has to implemented at the library level since its not supported by BoltDB
-func (b *BoltDB) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+func (b *BoltDB) WatchTree(directory string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan []*store.KVPair, error) {
 	return nil, store.ErrCallNotSupported
 }

--- a/store/boltdb/boltdb_test.go
+++ b/store/boltdb/boltdb_test.go
@@ -104,14 +104,14 @@ func TestConcurrentConnection(t *testing.T) {
 	err = kv2.Put(key2, value2, nil)
 	assert.NoError(t, err)
 
-	pair1, err1 := kv1.Get(key1)
+	pair1, err1 := kv1.Get(key1, nil)
 	assert.NoError(t, err1)
 	if assert.NotNil(t, pair1) {
 		assert.NotNil(t, pair1.Value)
 	}
 	assert.Equal(t, pair1.Value, value1)
 
-	pair2, err2 := kv2.Get(key2)
+	pair2, err2 := kv2.Get(key2, nil)
 	assert.NoError(t, err2)
 	if assert.NotNil(t, pair2) {
 		assert.NotNil(t, pair2.Value)

--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -168,10 +168,15 @@ func (s *Consul) getActiveSession(key string) (string, error) {
 
 // Get the value at "key", returns the last modified index
 // to use in conjunction to CAS calls
-func (s *Consul) Get(key string) (*store.KVPair, error) {
+func (s *Consul) Get(key string, opts *store.ReadOptions) (*store.KVPair, error) {
 	options := &api.QueryOptions{
 		AllowStale:        false,
 		RequireConsistent: true,
+	}
+
+	// Get options
+	if opts != nil {
+		options.RequireConsistent = opts.Consistent
 	}
 
 	pair, meta, err := s.client.KV().Get(s.normalize(key), options)
@@ -217,7 +222,7 @@ func (s *Consul) Put(key string, value []byte, opts *store.WriteOptions) error {
 
 // Delete a value at "key"
 func (s *Consul) Delete(key string) error {
-	if _, err := s.Get(key); err != nil {
+	if _, err := s.Get(key, nil); err != nil {
 		return err
 	}
 	_, err := s.client.KV().Delete(s.normalize(key), nil)
@@ -225,8 +230,8 @@ func (s *Consul) Delete(key string) error {
 }
 
 // Exists checks that the key exists inside the store
-func (s *Consul) Exists(key string) (bool, error) {
-	_, err := s.Get(key)
+func (s *Consul) Exists(key string, opts *store.ReadOptions) (bool, error) {
+	_, err := s.Get(key, opts)
 	if err != nil {
 		if err == store.ErrKeyNotFound {
 			return false, nil
@@ -237,7 +242,7 @@ func (s *Consul) Exists(key string) (bool, error) {
 }
 
 // List child nodes of a given directory
-func (s *Consul) List(directory string) ([]*store.KVPair, error) {
+func (s *Consul) List(directory string, opts *store.ReadOptions) ([]*store.KVPair, error) {
 	pairs, _, err := s.client.KV().List(s.normalize(directory), nil)
 	if err != nil {
 		return nil, err
@@ -264,7 +269,7 @@ func (s *Consul) List(directory string) ([]*store.KVPair, error) {
 
 // DeleteTree deletes a range of keys under a given directory
 func (s *Consul) DeleteTree(directory string) error {
-	if _, err := s.List(directory); err != nil {
+	if _, err := s.List(directory, nil); err != nil {
 		return err
 	}
 	_, err := s.client.KV().DeleteTree(s.normalize(directory), nil)
@@ -276,7 +281,7 @@ func (s *Consul) DeleteTree(directory string) error {
 // on errors. Upon creation, the current value will first
 // be sent to the channel. Providing a non-nil stopCh can
 // be used to stop watching.
-func (s *Consul) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+func (s *Consul) Watch(key string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan *store.KVPair, error) {
 	kv := s.client.KV()
 	watchCh := make(chan *store.KVPair)
 
@@ -328,7 +333,7 @@ func (s *Consul) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair
 // on errors. Upon creating a watch, the current childs values
 // will be sent to the channel .Providing a non-nil stopCh can
 // be used to stop watching.
-func (s *Consul) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+func (s *Consul) WatchTree(directory string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan []*store.KVPair, error) {
 	kv := s.client.KV()
 	watchCh := make(chan []*store.KVPair)
 
@@ -520,7 +525,7 @@ func (s *Consul) AtomicPut(key string, value []byte, previous *store.KVPair, opt
 		return false, nil, store.ErrKeyModified
 	}
 
-	pair, err := s.Get(key)
+	pair, err := s.Get(key, nil)
 	if err != nil {
 		return false, nil, err
 	}
@@ -538,7 +543,7 @@ func (s *Consul) AtomicDelete(key string, previous *store.KVPair) (bool, error) 
 	p := &api.KVPair{Key: s.normalize(key), ModifyIndex: previous.LastIndex, Flags: api.LockFlagValue}
 
 	// Extra Get operation to check on the key
-	_, err := s.Get(key)
+	_, err := s.Get(key, nil)
 	if err != nil && err == store.ErrKeyNotFound {
 		return false, err
 	}

--- a/store/etcd/v2/etcd.go
+++ b/store/etcd/v2/etcd.go
@@ -155,9 +155,14 @@ func keyNotFound(err error) bool {
 
 // Get the value at "key", returns the last modified
 // index to use in conjunction to Atomic calls
-func (s *Etcd) Get(key string) (pair *store.KVPair, err error) {
+func (s *Etcd) Get(key string, opts *store.ReadOptions) (pair *store.KVPair, err error) {
 	getOpts := &etcd.GetOptions{
 		Quorum: true,
+	}
+
+	// Get options
+	if opts != nil {
+		getOpts.Quorum = opts.Consistent
 	}
 
 	result, err := s.client.Get(context.Background(), s.normalize(key), getOpts)
@@ -205,8 +210,8 @@ func (s *Etcd) Delete(key string) error {
 }
 
 // Exists checks if the key exists inside the store
-func (s *Etcd) Exists(key string) (bool, error) {
-	_, err := s.Get(key)
+func (s *Etcd) Exists(key string, opts *store.ReadOptions) (bool, error) {
+	_, err := s.Get(key, opts)
 	if err != nil {
 		if err == store.ErrKeyNotFound {
 			return false, nil
@@ -221,9 +226,9 @@ func (s *Etcd) Exists(key string) (bool, error) {
 // on errors. Upon creation, the current value will first
 // be sent to the channel. Providing a non-nil stopCh can
 // be used to stop watching.
-func (s *Etcd) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
-	opts := &etcd.WatcherOptions{Recursive: false}
-	watcher := s.client.Watcher(s.normalize(key), opts)
+func (s *Etcd) Watch(key string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan *store.KVPair, error) {
+	wopts := &etcd.WatcherOptions{Recursive: false}
+	watcher := s.client.Watcher(s.normalize(key), wopts)
 
 	// watchCh is sending back events to the caller
 	watchCh := make(chan *store.KVPair)
@@ -232,7 +237,7 @@ func (s *Etcd) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, 
 		defer close(watchCh)
 
 		// Get the current value
-		pair, err := s.Get(key)
+		pair, err := s.Get(key, opts)
 		if err != nil {
 			return
 		}
@@ -270,7 +275,7 @@ func (s *Etcd) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, 
 // on errors. Upon creating a watch, the current childs values
 // will be sent to the channel. Providing a non-nil stopCh can
 // be used to stop watching.
-func (s *Etcd) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+func (s *Etcd) WatchTree(directory string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan []*store.KVPair, error) {
 	watchOpts := &etcd.WatcherOptions{Recursive: true}
 	watcher := s.client.Watcher(s.normalize(directory), watchOpts)
 
@@ -281,7 +286,7 @@ func (s *Etcd) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*st
 		defer close(watchCh)
 
 		// Get child values
-		list, err := s.List(directory)
+		list, err := s.List(directory, opts)
 		if err != nil {
 			return
 		}
@@ -303,7 +308,7 @@ func (s *Etcd) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*st
 				return
 			}
 
-			list, err = s.List(directory)
+			list, err = s.List(directory, opts)
 			if err != nil {
 				return
 			}
@@ -401,11 +406,16 @@ func (s *Etcd) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
 }
 
 // List child nodes of a given directory
-func (s *Etcd) List(directory string) ([]*store.KVPair, error) {
+func (s *Etcd) List(directory string, opts *store.ReadOptions) ([]*store.KVPair, error) {
 	getOpts := &etcd.GetOptions{
 		Quorum:    true,
 		Recursive: true,
 		Sort:      true,
+	}
+
+	// Get options
+	if opts != nil {
+		getOpts.Quorum = opts.Consistent
 	}
 
 	resp, err := s.client.Get(context.Background(), s.normalize(directory), getOpts)

--- a/store/mock/mock.go
+++ b/store/mock/mock.go
@@ -31,8 +31,8 @@ func (s *Mock) Put(key string, value []byte, opts *store.WriteOptions) error {
 }
 
 // Get mock
-func (s *Mock) Get(key string) (*store.KVPair, error) {
-	args := s.Mock.Called(key)
+func (s *Mock) Get(key string, opts *store.ReadOptions) (*store.KVPair, error) {
+	args := s.Mock.Called(key, opts)
 	return args.Get(0).(*store.KVPair), args.Error(1)
 }
 
@@ -43,20 +43,20 @@ func (s *Mock) Delete(key string) error {
 }
 
 // Exists mock
-func (s *Mock) Exists(key string) (bool, error) {
-	args := s.Mock.Called(key)
+func (s *Mock) Exists(key string, opts *store.ReadOptions) (bool, error) {
+	args := s.Mock.Called(key, opts)
 	return args.Bool(0), args.Error(1)
 }
 
 // Watch mock
-func (s *Mock) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
-	args := s.Mock.Called(key, stopCh)
+func (s *Mock) Watch(key string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan *store.KVPair, error) {
+	args := s.Mock.Called(key, stopCh, opts)
 	return args.Get(0).(<-chan *store.KVPair), args.Error(1)
 }
 
 // WatchTree mock
-func (s *Mock) WatchTree(prefix string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
-	args := s.Mock.Called(prefix, stopCh)
+func (s *Mock) WatchTree(prefix string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan []*store.KVPair, error) {
+	args := s.Mock.Called(prefix, stopCh, opts)
 	return args.Get(0).(chan []*store.KVPair), args.Error(1)
 }
 
@@ -67,8 +67,8 @@ func (s *Mock) NewLock(key string, options *store.LockOptions) (store.Locker, er
 }
 
 // List mock
-func (s *Mock) List(prefix string) ([]*store.KVPair, error) {
-	args := s.Mock.Called(prefix)
+func (s *Mock) List(prefix string, opts *store.ReadOptions) ([]*store.KVPair, error) {
+	args := s.Mock.Called(prefix, opts)
 	return args.Get(0).([]*store.KVPair), args.Error(1)
 }
 

--- a/store/redis/redis.go
+++ b/store/redis/redis.go
@@ -113,7 +113,7 @@ func (r *Redis) setTTL(key string, val *store.KVPair, ttl time.Duration) error {
 }
 
 // Get a value given its key
-func (r *Redis) Get(key string) (*store.KVPair, error) {
+func (r *Redis) Get(key string, opts *store.ReadOptions) (*store.KVPair, error) {
 	return r.get(normalize(key))
 }
 
@@ -138,14 +138,14 @@ func (r *Redis) Delete(key string) error {
 }
 
 // Exists verify if a Key exists in the store
-func (r *Redis) Exists(key string) (bool, error) {
+func (r *Redis) Exists(key string, opts *store.ReadOptions) (bool, error) {
 	return r.client.Exists(normalize(key)).Result()
 }
 
 // Watch for changes on a key
 // glitch: we use notified-then-retrieve to retrieve *store.KVPair.
 // so the responses may sometimes inaccurate
-func (r *Redis) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+func (r *Redis) Watch(key string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan *store.KVPair, error) {
 	watchCh := make(chan *store.KVPair)
 	nKey := normalize(key)
 
@@ -269,7 +269,7 @@ func (s *subscribe) receiveLoop(msgCh chan *redis.Message, stopCh <-chan struct{
 
 // WatchTree watches for changes on child nodes under
 // a given directory
-func (r *Redis) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+func (r *Redis) WatchTree(directory string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan []*store.KVPair, error) {
 	watchCh := make(chan []*store.KVPair)
 	nKey := normalize(directory)
 
@@ -353,7 +353,7 @@ func (l *redisLock) Lock(stopCh chan struct{}) (<-chan struct{}, error) {
 	}
 
 	// wait for changes on the key
-	watch, err := l.redis.Watch(l.key, stopCh)
+	watch, err := l.redis.Watch(l.key, stopCh, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +444,7 @@ func (l *redisLock) Unlock() error {
 }
 
 // List the content of a given prefix
-func (r *Redis) List(directory string) ([]*store.KVPair, error) {
+func (r *Redis) List(directory string, opts *store.ReadOptions) ([]*store.KVPair, error) {
 	return r.list(normalize(directory))
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -72,20 +72,20 @@ type Store interface {
 	Put(key string, value []byte, options *WriteOptions) error
 
 	// Get a value given its key
-	Get(key string) (*KVPair, error)
+	Get(key string, options *ReadOptions) (*KVPair, error)
 
 	// Delete the value at the specified key
 	Delete(key string) error
 
 	// Verify if a Key exists in the store
-	Exists(key string) (bool, error)
+	Exists(key string, options *ReadOptions) (bool, error)
 
 	// Watch for changes on a key
-	Watch(key string, stopCh <-chan struct{}) (<-chan *KVPair, error)
+	Watch(key string, stopCh <-chan struct{}, options *ReadOptions) (<-chan *KVPair, error)
 
 	// WatchTree watches for changes on child nodes under
 	// a given directory
-	WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*KVPair, error)
+	WatchTree(directory string, stopCh <-chan struct{}, options *ReadOptions) (<-chan []*KVPair, error)
 
 	// NewLock creates a lock for a given key.
 	// The returned Locker is not held and must be acquired
@@ -93,7 +93,7 @@ type Store interface {
 	NewLock(key string, options *LockOptions) (Locker, error)
 
 	// List the content of a given prefix
-	List(directory string) ([]*KVPair, error)
+	List(directory string, options *ReadOptions) ([]*KVPair, error)
 
 	// DeleteTree deletes a range of keys under a given directory
 	DeleteTree(directory string) error
@@ -120,6 +120,16 @@ type KVPair struct {
 type WriteOptions struct {
 	IsDir bool
 	TTL   time.Duration
+}
+
+// ReadOptions contains optional request parameters
+type ReadOptions struct {
+	// Consistent defines if the behavior of a Get operation is
+	// linearizable or not. Linearizability allows us to 'see'
+	// objects based on a real-time total order as opposed to
+	// an arbitrary order or with stale values ('inconsistent'
+	// scenario).
+	Consistent bool
 }
 
 // LockOptions contains optional request parameters

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -67,7 +67,7 @@ func (s *Zookeeper) setTimeout(time time.Duration) {
 
 // Get the value at "key", returns the last modified index
 // to use in conjunction to Atomic calls
-func (s *Zookeeper) Get(key string) (pair *store.KVPair, err error) {
+func (s *Zookeeper) Get(key string, opts *store.ReadOptions) (pair *store.KVPair, err error) {
 
 	resp, meta, err := s.get(key)
 	if err != nil {
@@ -114,7 +114,7 @@ func (s *Zookeeper) createFullPath(path []string, data []byte, ephemeral bool) e
 func (s *Zookeeper) Put(key string, value []byte, opts *store.WriteOptions) error {
 	fkey := s.normalize(key)
 
-	exists, err := s.Exists(key)
+	exists, err := s.Exists(key, nil)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func (s *Zookeeper) Delete(key string) error {
 }
 
 // Exists checks if the key exists inside the store
-func (s *Zookeeper) Exists(key string) (bool, error) {
+func (s *Zookeeper) Exists(key string, opts *store.ReadOptions) (bool, error) {
 	exists, _, err := s.client.Exists(s.normalize(key))
 	if err != nil {
 		return false, err
@@ -155,7 +155,7 @@ func (s *Zookeeper) Exists(key string) (bool, error) {
 // on errors. Upon creation, the current value will first
 // be sent to the channel. Providing a non-nil stopCh can
 // be used to stop watching.
-func (s *Zookeeper) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+func (s *Zookeeper) Watch(key string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan *store.KVPair, error) {
 	// Catch zk notifications and fire changes into the channel.
 	watchCh := make(chan *store.KVPair)
 	go func() {
@@ -195,7 +195,7 @@ func (s *Zookeeper) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVP
 // on errors. Upon creating a watch, the current childs values
 // will be sent to the channel .Providing a non-nil stopCh can
 // be used to stop watching.
-func (s *Zookeeper) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+func (s *Zookeeper) WatchTree(directory string, stopCh <-chan struct{}, opts *store.ReadOptions) (<-chan []*store.KVPair, error) {
 	// Catch zk notifications and fire changes into the channel.
 	watchCh := make(chan []*store.KVPair)
 	go func() {
@@ -209,7 +209,7 @@ func (s *Zookeeper) WatchTree(directory string, stopCh <-chan struct{}) (<-chan 
 				return
 			}
 			if fireEvt {
-				kvs, err := s.getKVPairs(directory, keys)
+				kvs, err := s.getKVPairs(directory, keys, opts)
 				if err != nil {
 					// Failed to get values for one or more of the keys,
 					// the list may be out of date so try again.
@@ -234,7 +234,7 @@ func (s *Zookeeper) WatchTree(directory string, stopCh <-chan struct{}) (<-chan 
 }
 
 // List child nodes of a given directory
-func (s *Zookeeper) List(directory string) ([]*store.KVPair, error) {
+func (s *Zookeeper) List(directory string, opts *store.ReadOptions) ([]*store.KVPair, error) {
 	keys, _, err := s.client.Children(s.normalize(directory))
 	if err != nil {
 		if err == zk.ErrNoNode {
@@ -243,11 +243,11 @@ func (s *Zookeeper) List(directory string) ([]*store.KVPair, error) {
 		return nil, err
 	}
 
-	kvs, err := s.getKVPairs(directory, keys)
+	kvs, err := s.getKVPairs(directory, keys, opts)
 	if err != nil {
 		// If node is not found: List is out of date, retry
 		if err == store.ErrKeyNotFound {
-			return s.List(directory)
+			return s.List(directory, opts)
 		}
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (s *Zookeeper) List(directory string) ([]*store.KVPair, error) {
 
 // DeleteTree deletes a range of keys under a given directory
 func (s *Zookeeper) DeleteTree(directory string) error {
-	pairs, err := s.List(directory)
+	pairs, err := s.List(directory, nil)
 	if err != nil {
 		return err
 	}
@@ -510,11 +510,11 @@ func (s *Zookeeper) getW(key string) ([]byte, *zk.Stat, <-chan zk.Event, error) 
 	return resp, meta, ech, nil
 }
 
-func (s *Zookeeper) getKVPairs(directory string, keys []string) ([]*store.KVPair, error) {
+func (s *Zookeeper) getKVPairs(directory string, keys []string, opts *store.ReadOptions) ([]*store.KVPair, error) {
 	kvs := []*store.KVPair{}
 
 	for _, key := range keys {
-		pair, err := s.Get(strings.TrimSuffix(directory, "/") + s.normalize(key))
+		pair, err := s.Get(strings.TrimSuffix(directory, "/")+s.normalize(key), opts)
 		if err != nil {
 			return nil, err
 		}

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -62,7 +62,7 @@ func checkPairNotNil(t *testing.T, pair *store.KVPair) {
 
 func testPutGetDeleteExists(t *testing.T, kv store.Store) {
 	// Get a not exist key should return ErrKeyNotFound
-	pair, err := kv.Get("testPutGetDelete_not_exist_key")
+	pair, err := kv.Get("testPutGetDelete_not_exist_key", nil)
 	assert.Equal(t, store.ErrKeyNotFound, err)
 
 	value := []byte("bar")
@@ -78,14 +78,14 @@ func testPutGetDeleteExists(t *testing.T, kv store.Store) {
 		assert.NoError(t, err)
 
 		// Get should return the value and an incremented index
-		pair, err = kv.Get(key)
+		pair, err = kv.Get(key, nil)
 		assert.NoError(t, err)
 		checkPairNotNil(t, pair)
 		assert.Equal(t, pair.Value, value)
 		assert.NotEqual(t, pair.LastIndex, 0)
 
 		// Exists should return true
-		exists, err := kv.Exists(key)
+		exists, err := kv.Exists(key, nil)
 		assert.NoError(t, err)
 		assert.True(t, exists)
 
@@ -94,13 +94,13 @@ func testPutGetDeleteExists(t *testing.T, kv store.Store) {
 		assert.NoError(t, err)
 
 		// Get should fail
-		pair, err = kv.Get(key)
+		pair, err = kv.Get(key, nil)
 		assert.Error(t, err)
 		assert.Nil(t, pair)
 		assert.Nil(t, pair)
 
 		// Exists should return false
-		exists, err = kv.Exists(key)
+		exists, err = kv.Exists(key, nil)
 		assert.NoError(t, err)
 		assert.False(t, exists)
 	}
@@ -116,7 +116,7 @@ func testWatch(t *testing.T, kv store.Store) {
 	assert.NoError(t, err)
 
 	stopCh := make(<-chan struct{})
-	events, err := kv.Watch(key, stopCh)
+	events, err := kv.Watch(key, stopCh, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, events)
 
@@ -183,7 +183,7 @@ func testWatchTree(t *testing.T, kv store.Store) {
 	assert.NoError(t, err)
 
 	stopCh := make(<-chan struct{})
-	events, err := kv.WatchTree(dir, stopCh)
+	events, err := kv.WatchTree(dir, stopCh, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, events)
 
@@ -228,7 +228,7 @@ func testAtomicPut(t *testing.T, kv store.Store) {
 	assert.NoError(t, err)
 
 	// Get should return the value and an incremented index
-	pair, err := kv.Get(key)
+	pair, err := kv.Get(key, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 	assert.Equal(t, pair.Value, value)
@@ -263,7 +263,7 @@ func testAtomicPutCreate(t *testing.T, kv store.Store) {
 	assert.True(t, success)
 
 	// Get should return the value and an incremented index
-	pair, err := kv.Get(key)
+	pair, err := kv.Get(key, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 	assert.Equal(t, pair.Value, value)
@@ -295,7 +295,7 @@ func testAtomicDelete(t *testing.T, kv store.Store) {
 	assert.NoError(t, err)
 
 	// Get should return the value and an incremented index
-	pair, err := kv.Get(key)
+	pair, err := kv.Get(key, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 	assert.Equal(t, pair.Value, value)
@@ -336,7 +336,7 @@ func testLockUnlock(t *testing.T, kv store.Store) {
 	assert.NotNil(t, lockChan)
 
 	// Get should work
-	pair, err := kv.Get(key)
+	pair, err := kv.Get(key, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 	assert.Equal(t, pair.Value, value)
@@ -352,7 +352,7 @@ func testLockUnlock(t *testing.T, kv store.Store) {
 	assert.NotNil(t, lockChan)
 
 	// Get should work
-	pair, err = kv.Get(key)
+	pair, err = kv.Get(key, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 	assert.Equal(t, pair.Value, value)
@@ -383,7 +383,7 @@ func testLockTTL(t *testing.T, kv store.Store, otherConn store.Store) {
 	assert.NotNil(t, lockChan)
 
 	// Get should work
-	pair, err := otherConn.Get(key)
+	pair, err := otherConn.Get(key, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 	assert.Equal(t, pair.Value, value)
@@ -449,7 +449,7 @@ func testLockTTL(t *testing.T, kv store.Store, otherConn store.Store) {
 	}
 
 	// Get should work with the new value
-	pair, err = kv.Get(key)
+	pair, err = kv.Get(key, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 	assert.Equal(t, pair.Value, value)
@@ -475,12 +475,12 @@ func testPutTTL(t *testing.T, kv store.Store, otherConn store.Store) {
 	assert.NoError(t, err)
 
 	// Get on firstKey should work
-	pair, err := kv.Get(firstKey)
+	pair, err := kv.Get(firstKey, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 
 	// Get on secondKey should work
-	pair, err = kv.Get(secondKey)
+	pair, err = kv.Get(secondKey, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 
@@ -491,12 +491,12 @@ func testPutTTL(t *testing.T, kv store.Store, otherConn store.Store) {
 	time.Sleep(3 * time.Second)
 
 	// Get on firstKey shouldn't work
-	pair, err = kv.Get(firstKey)
+	pair, err = kv.Get(firstKey, nil)
 	assert.Error(t, err)
 	assert.Nil(t, pair)
 
 	// Get on secondKey shouldn't work
-	pair, err = kv.Get(secondKey)
+	pair, err = kv.Get(secondKey, nil)
 	assert.Error(t, err)
 	assert.Nil(t, pair)
 }
@@ -520,7 +520,7 @@ func testList(t *testing.T, kv store.Store) {
 
 	// List should work and return the two correct values
 	for _, parent := range []string{prefix, prefix + "/"} {
-		pairs, err := kv.List(parent)
+		pairs, err := kv.List(parent, nil)
 		assert.NoError(t, err)
 		if assert.NotNil(t, pairs) {
 			assert.Equal(t, len(pairs), 2)
@@ -538,7 +538,7 @@ func testList(t *testing.T, kv store.Store) {
 	}
 
 	// List should fail: the key does not exist
-	pairs, err := kv.List("idontexist")
+	pairs, err := kv.List("idontexist", nil)
 	assert.Equal(t, store.ErrKeyNotFound, err)
 	assert.Nil(t, pairs)
 }
@@ -561,14 +561,14 @@ func testDeleteTree(t *testing.T, kv store.Store) {
 	assert.NoError(t, err)
 
 	// Get should work on the first Key
-	pair, err := kv.Get(firstKey)
+	pair, err := kv.Get(firstKey, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 	assert.Equal(t, pair.Value, firstValue)
 	assert.NotEqual(t, pair.LastIndex, 0)
 
 	// Get should work on the second Key
-	pair, err = kv.Get(secondKey)
+	pair, err = kv.Get(secondKey, nil)
 	assert.NoError(t, err)
 	checkPairNotNil(t, pair)
 	assert.Equal(t, pair.Value, secondValue)
@@ -579,11 +579,11 @@ func testDeleteTree(t *testing.T, kv store.Store) {
 	assert.NoError(t, err)
 
 	// Get should fail on both keys
-	pair, err = kv.Get(firstKey)
+	pair, err = kv.Get(firstKey, nil)
 	assert.Error(t, err)
 	assert.Nil(t, pair)
 
-	pair, err = kv.Get(secondKey)
+	pair, err = kv.Get(secondKey, nil)
 	assert.Error(t, err)
 	assert.Nil(t, pair)
 }


### PR DESCRIPTION
Carry #33 

____

This commit introduces ReadOptions to the store interface
in order to be able to control the level of consistency
for Get operations.

By default, Get operations are linearizable (provided that
the backend offers such guarantee), but a user could place
the Consistency flag at 'false' to disable linearizability
for lower latency requirements.

This only affects Consul and etcd which offer the choice of
linearizability for Get operations.

Signed-off-by: Lukas Prettenthaler <lukas@noenv.com>
Signed-off-by: Alexandre Beslic <abeslic@abronan.com>