### PR TITLE
 etcd: remove mutex side keys from results in `List`

### DIFF
--- a/store/etcd/v2/etcd_test.go
+++ b/store/etcd/v2/etcd_test.go
@@ -53,6 +53,7 @@ func TestEtcdStore(t *testing.T) {
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestLockTTL(t, kv, lockKV)
+	testutils.RunTestListLock(t, kv)
 	testutils.RunTestTTL(t, kv, ttlKV)
 	testutils.RunCleanup(t, kv)
 }

--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -16,7 +16,7 @@ import (
 const (
 	defaultLockTTL     = 20 * time.Second
 	etcdDefaultTimeout = 5 * time.Second
-	lockSuffix         = "_lock"
+	lockSuffix         = "___lock"
 )
 
 // EtcdV3 is the receiver type for the
@@ -518,8 +518,8 @@ func (s *EtcdV3) list(directory string, opts *store.ReadOptions) (int64, []*stor
 			continue
 		}
 
-		// Allow to filter the _lock entry when the mutex key directory is given
-		if strings.Contains(string(n.Key), lockSuffix+"/") {
+		// Filter out etcd mutex side keys with `___lock` suffix
+		if strings.Contains(string(n.Key), lockSuffix) {
 			continue
 		}
 

--- a/store/etcd/v3/etcd_test.go
+++ b/store/etcd/v3/etcd_test.go
@@ -53,29 +53,7 @@ func TestEtcdV3Store(t *testing.T) {
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestLockTTL(t, kv, lockKV)
+	testutils.RunTestListLock(t, kv)
 	testutils.RunTestTTL(t, kv, ttlKV)
 	testutils.RunCleanup(t, kv)
-}
-
-func TestEtcdListLockKey(t *testing.T) {
-	lockKV := makeEtcdV3Client(t)
-
-	key := "testLocketcdv3"
-	value := []byte("bar")
-
-	// We should be able to create a new lock on key
-	lock, err := lockKV.NewLock(key, &store.LockOptions{Value: value, TTL: 2 * time.Second})
-	assert.NoError(t, err)
-	assert.NotNil(t, lock)
-
-	// Lock should successfully succeed or block
-	lockChan, err := lock.Lock(nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, lockChan)
-
-	pairs, err := lockKV.List(key)
-	assert.NoError(t, err)
-	assert.NotNil(t, pairs)
-	assert.Equal(t, 1, len(pairs))
-	assert.Equal(t, key, pairs[0].Key)
 }

--- a/store/etcd/v3/etcd_test.go
+++ b/store/etcd/v3/etcd_test.go
@@ -56,3 +56,26 @@ func TestEtcdV3Store(t *testing.T) {
 	testutils.RunTestTTL(t, kv, ttlKV)
 	testutils.RunCleanup(t, kv)
 }
+
+func TestEtcdListLockKey(t *testing.T) {
+	lockKV := makeEtcdV3Client(t)
+
+	key := "testLocketcdv3"
+	value := []byte("bar")
+
+	// We should be able to create a new lock on key
+	lock, err := lockKV.NewLock(key, &store.LockOptions{Value: value, TTL: 2 * time.Second})
+	assert.NoError(t, err)
+	assert.NotNil(t, lock)
+
+	// Lock should successfully succeed or block
+	lockChan, err := lock.Lock(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, lockChan)
+
+	pairs, err := lockKV.List(key)
+	assert.NoError(t, err)
+	assert.NotNil(t, pairs)
+	assert.Equal(t, 1, len(pairs))
+	assert.Equal(t, key, pairs[0].Key)
+}


### PR DESCRIPTION
Carry and completes #31
___
This PR aligns the results returned by `List` by filtering `*_lock` keys from the results.

Additionally, we test for this case for both etcd v2 and etcd v3 and we change the lock suffix to be `___lock` instead of `_lock` to avoid collision with similar key names following the pattern of using a simple underscore (might brake backward compatibility of `List` results for client the using master version of libkv).

@nmengin PTAL :)