### PR TITLE
consul: Remove hardcoded http scheme

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -74,7 +74,6 @@ func New(endpoints []string, options *store.Config) (store.Store, error) {
 	s.config = config
 	config.HttpClient = http.DefaultClient
 	config.Address = endpoints[0]
-	config.Scheme = "http"
 
 	// Set options
 	if options != nil {


### PR DESCRIPTION
Carry #34 
___
Consul seems to fill the config out with http scheme
by default. As of now libkv was also explicitely
putting the scheme to http thus conflicting with
the use of environment variables such as 'CONSUL_HTTP_SSL'.

This commit simply removes the line overriding the
http scheme thus using the default Consul behavior.