### PR TITLE
 consul: Allow consistency tweaking for List call

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -242,7 +242,19 @@ func (s *Consul) Exists(key string, opts *store.ReadOptions) (bool, error) {
 
 // List child nodes of a given directory
 func (s *Consul) List(directory string, opts *store.ReadOptions) ([]*store.KVPair, error) {
-	pairs, _, err := s.client.KV().List(s.normalize(directory), nil)
+	options := &api.QueryOptions{
+		AllowStale:        false,
+		RequireConsistent: true,
+	}
+
+	if opts != nil {
+		if !opts.Consistent {
+			options.AllowStale = true
+			options.RequireConsistent = false
+		}
+	}
+
+	pairs, _, err := s.client.KV().List(s.normalize(directory), options)
 	if err != nil {
 		return nil, err
 	}

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -1,7 +1,6 @@
 package zookeeper
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -276,7 +275,6 @@ func (s *Zookeeper) List(directory string, opts *store.ReadOptions) ([]*store.KV
 	children := make([]string, 0)
 	err := s.listChildrenRecursive(&children, directory)
 	if err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 


### PR DESCRIPTION
This adds the use of consistency options to the List call which was omitted for now.

Signed-off-by: Alexandre Beslic <abeslic@abronan.com>