### PR TITLE
etcd: Move out initial Get/List operation from goroutine in Watch methods

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -325,7 +325,6 @@ func (s *Consul) Watch(key string, stopCh <-chan struct{}, opts *store.ReadOptio
 			opts.WaitIndex = meta.LastIndex
 
 			// Return the value to the channel
-			// FIXME: What happens when a key is deleted?
 			if pair != nil {
 				watchCh <- &store.KVPair{
 					Key:       pair.Key,

--- a/store/etcd/v2/etcd.go
+++ b/store/etcd/v2/etcd.go
@@ -233,14 +233,14 @@ func (s *Etcd) Watch(key string, stopCh <-chan struct{}, opts *store.ReadOptions
 	// watchCh is sending back events to the caller
 	watchCh := make(chan *store.KVPair)
 
+	// Get the current value
+	pair, err := s.Get(key, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	go func() {
 		defer close(watchCh)
-
-		// Get the current value
-		pair, err := s.Get(key, opts)
-		if err != nil {
-			return
-		}
 
 		// Push the current value through the channel.
 		watchCh <- pair
@@ -282,14 +282,14 @@ func (s *Etcd) WatchTree(directory string, stopCh <-chan struct{}, opts *store.R
 	// watchCh is sending back events to the caller
 	watchCh := make(chan []*store.KVPair)
 
+	// List current children
+	list, err := s.List(directory, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	go func() {
 		defer close(watchCh)
-
-		// Get child values
-		list, err := s.List(directory, opts)
-		if err != nil {
-			return
-		}
 
 		// Push the current value through the channel.
 		watchCh <- list

--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -199,15 +199,15 @@ func (s *EtcdV3) Watch(key string, stopCh <-chan struct{}, opts *store.ReadOptio
 	// respCh is sending back events to the caller
 	respCh := make(chan *store.KVPair)
 
+	// Get the current value
+	pair, err := s.Get(key, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	go func() {
 		defer wc.Close()
 		defer close(respCh)
-
-		// Get the current value
-		pair, err := s.Get(key, opts)
-		if err != nil {
-			return
-		}
 
 		// Push the current value through the channel.
 		respCh <- pair


### PR DESCRIPTION
This PR moves out the Get and List operations
that are happening initially from the Watch goroutine
in order to avoid races if using the first current
revision we return from the channel. This also
improves error management as we used to just exit
the goroutine when the Get/List operation failed.

Signed-off-by: Alexandre Beslic <abeslic@abronan.com>