### PR TITLE
boltdb: Switch to active fork

### DIFF
--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/boltdb/bolt"
+	"github.com/coreos/bbolt"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 )


### PR DESCRIPTION
The maintenance of the boltdb project moved to a
fork: github.com/coreos/bbolt. While the original
boltdb repository is itself at a stable state, we
switch to this active fork for the improved reliability
and stability goals.

Fixes #27

Signed-off-by: Alexandre Beslic <abeslic@abronan.com>